### PR TITLE
Fix broken IRS link

### DIFF
--- a/REGULATORY.md
+++ b/REGULATORY.md
@@ -14,7 +14,7 @@ If you instead donate through a third-party service – such as Benevity, GoFund
 
 The T. Greg Doucette Foundation is a 501(c)(3) public charity.
 
-You can view [our determination letter on the IRS website](https://apps.irs.gov/app/eos/details/#:~:text=FinalLetter_85%2D2110706_TGREGDOUCETTEFOUNDATIONINC_07222020_00.tif).
+You can view [our determination letter on the IRS website](https://apps.irs.gov/pub/epostcard/dl/FinalLetter_85-2110706_TGREGDOUCETTEFOUNDATIONINC_07222020_00.tif).
 
 ## Contact Information
 


### PR DESCRIPTION
Link directly to document download instead of IRS search because it did not auto-populate the EIN.

Original url resolved to:
![image](https://github.com/LawDevNull/BullCityFoodraiser/assets/53440410/2567c786-5c3c-40cf-96ca-c35df89d7b11)

Really excited about your nonprofit!
